### PR TITLE
Create mkdocs.yml to auto build and upload docs artifact

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -10,6 +10,11 @@ on:
     pull_request:
         branches:
             - main
+        paths:
+            - 'docs/**'
+            - 'mkdocs.yml'
+            - 'race_car_ws/src/test_package/**'
+            - '.github/workflows/mkdocs.yml'
     workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Create a workflow to automatically build a new mkdocs site on changes and upload the artifact. Ideally we would want to use github pages to host this. As this requires us to either make the repo public, an enterprise account or to move the repo into a private non-organization repo of a pro user, we should check with Sven on this.